### PR TITLE
Apply nt-page structure to examples

### DIFF
--- a/apps/nt-stylesheet/examples/avatar.html
+++ b/apps/nt-stylesheet/examples/avatar.html
@@ -1,5 +1,8 @@
-<main>
-    <h2>Avatar size</h2>
+<div class="nt-page">
+    <div class="nt-page-header">
+        <h2 class="nt-title">Avatar size</h2>
+    </div>
+    <div class="nt-page-body">
     <span class="nt-avatar-wrapper">
         <img
             class="nt-avatar nt-avatar-xs"
@@ -61,4 +64,5 @@
         />
         <span class="nt-avatar-status nt-avatar-status--busy"></span>
     </span>
-</main>
+    </div>
+</div>

--- a/apps/nt-stylesheet/examples/badge.html
+++ b/apps/nt-stylesheet/examples/badge.html
@@ -1,5 +1,8 @@
-<main>
-    <h2 class="text-3xl font-semibold mb-4">Badge Variants</h2>
+<div class="nt-page">
+    <div class="nt-page-header">
+        <h2 class="nt-title text-3xl font-semibold mb-4">Badge Variants</h2>
+    </div>
+    <div class="nt-page-body">
     <span class="nt-badge">Default</span>
     <span class="nt-badge nt-badge-info">Info</span>
     <span class="nt-badge nt-badge-success">Success</span>
@@ -17,4 +20,5 @@
     <span class="nt-badge nt-badge-success nt-badge-rounded">S</span>
     <span class="nt-badge nt-badge-warning nt-badge-rounded">W</span>
     <span class="nt-badge nt-badge-danger nt-badge-rounded">D</span>
-</main>
+    </div>
+</div>

--- a/apps/nt-stylesheet/examples/breadcrumb.html
+++ b/apps/nt-stylesheet/examples/breadcrumb.html
@@ -1,5 +1,8 @@
-<main>
-  <h1 class="nt-page-header-title">Breadcrumb</h1>
+<div class="nt-page">
+  <div class="nt-page-header">
+    <h1 class="nt-title nt-page-header-title">Breadcrumb</h1>
+  </div>
+  <div class="nt-page-body">
   <div style="background-color: white; padding: 16px;">
     <nav class="nt-breadcrumb">
       <ol class="nt-breadcrumb-list">
@@ -15,4 +18,5 @@
       </ol>
     </nav>
   </div>
-</main>
+  </div>
+</div>

--- a/apps/nt-stylesheet/examples/card.html
+++ b/apps/nt-stylesheet/examples/card.html
@@ -1,4 +1,5 @@
-<main>
+<div class="nt-page">
+    <div class="nt-page-body">
     <!-- Small Card -->
     <div class="nt-card-small">
         <div class="nt-card-header">
@@ -103,4 +104,4 @@
             <button class="nt-btn-danger">Retry</button>
         </div>
     </div>
-</main>
+</div>

--- a/apps/nt-stylesheet/examples/checkbox.html
+++ b/apps/nt-stylesheet/examples/checkbox.html
@@ -1,5 +1,8 @@
-<main>
-    <h2>Basic Checkbox</h2>
+<div class="nt-page">
+    <div class="nt-page-header">
+        <h2 class="nt-title">Basic Checkbox</h2>
+    </div>
+    <div class="nt-page-body">
     <!-- Default Checkbox -->
     <label class="nt-checkbox">
         <input type="checkbox" />
@@ -30,4 +33,5 @@
         <input type="checkbox" id="indeterminate-disabled" disabled />
         Indeterminate disabled
     </label>
-</main>
+    </div>
+</div>

--- a/apps/nt-stylesheet/examples/inputs.html
+++ b/apps/nt-stylesheet/examples/inputs.html
@@ -1,5 +1,8 @@
-<main>
-    <h2 class="text-3xl font-semibold mb-4">Basic Inputs</h2>
+<div class="nt-page">
+    <div class="nt-page-header">
+        <h2 class="nt-title text-3xl font-semibold mb-4">Basic Inputs</h2>
+    </div>
+    <div class="nt-page-body">
     <input
         type="text"
         placeholder="Input default"
@@ -81,4 +84,5 @@
         />
         <span class="nt-input-icon">🚀</span>
     </div>
-</main>
+    </div>
+</div>

--- a/apps/nt-stylesheet/examples/label.html
+++ b/apps/nt-stylesheet/examples/label.html
@@ -1,8 +1,10 @@
-<main>
-    <div class="flex flex-col gap-5">
+<div class="nt-page">
+    <div class="nt-page-body">
+        <div class="flex flex-col gap-5">
         <label class="nt-label nt-label-hint mb-1">Hint Label</label>
         <label class="nt-label nt-label-form-field mb-1"
             >Form field label</label
         >
+        </div>
     </div>
-</main>
+</div>

--- a/apps/nt-stylesheet/examples/layout.html
+++ b/apps/nt-stylesheet/examples/layout.html
@@ -1,4 +1,5 @@
-<main>
+<div class="nt-page">
+    <div class="nt-page-body">
     <div class="nt-layout" id="main-layout">
         <!-- Side Menu -->
         <aside class="nt-side-menu">
@@ -137,4 +138,5 @@
     <div class="nt-overlay" id="ntOverlay"></div>
 
     <script defer src="./dist/scripts/nt-menu-toggle.js"></script>
-</main>
+    </div>
+</div>

--- a/apps/nt-stylesheet/examples/modal.html
+++ b/apps/nt-stylesheet/examples/modal.html
@@ -1,5 +1,6 @@
-<main>
-    <div class="flex flex-col gap-5">
+<div class="nt-page">
+    <div class="nt-page-body">
+        <div class="flex flex-col gap-5">
         <button
             class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 w-[200px]"
             data-nt-toggle="modal"
@@ -124,4 +125,5 @@
             </div>
         </div>
     </div>
-</main>
+    </div>
+</div>

--- a/apps/nt-stylesheet/examples/radio-group.html
+++ b/apps/nt-stylesheet/examples/radio-group.html
@@ -1,5 +1,8 @@
-<main>
-    <h2 class="text-3xl font-semibold mb-4">Radio grid</h2>
+<div class="nt-page">
+    <div class="nt-page-header">
+        <h2 class="nt-title text-3xl font-semibold mb-4">Radio grid</h2>
+    </div>
+    <div class="nt-page-body">
     <div class="nt-radio-column mb-10">
         <label class="nt-radio">
             <input type="radio" name="choice" value="1" />
@@ -26,4 +29,5 @@
             Row 2
         </label>
     </div>
-</main>
+    </div>
+</div>

--- a/apps/nt-stylesheet/examples/switch.html
+++ b/apps/nt-stylesheet/examples/switch.html
@@ -1,4 +1,5 @@
-<main>
+<div class="nt-page">
+    <div class="nt-page-body">
     <div class="mb-4">
         <h2 class="text-3xl font-semibold mb-4">Default</h2>
         <label class="nt-switch">
@@ -32,4 +33,4 @@
             <span class="nt-switch-slider"></span>
         </label>
     </div>
-</main>
+</div>


### PR DESCRIPTION
## Summary
- use `<div class="nt-page">` layout for demo html files
- add page headers and bodies to examples

## Testing
- `npm test` *(fails: Need to install nx)*
- `npm run lint` *(fails: Need to install nx)*

------
https://chatgpt.com/codex/tasks/task_e_686851a08e148323a5319359969b22ce