### PR TITLE
Add cards component

### DIFF
--- a/apps/nt-stylesheet/examples/cards.html
+++ b/apps/nt-stylesheet/examples/cards.html
@@ -1,0 +1,33 @@
+<div class="nt-page">
+    <div class="nt-page-header">
+        <h2 class="nt-title">Cards Group</h2>
+    </div>
+    <div class="nt-page-body">
+        <div class="nt-cards">
+            <div class="nt-card-default">
+                <div class="nt-card-header">
+                    <span class="nt-card-title">Card One</span>
+                </div>
+                <div class="nt-card-content">
+                    <p>Example content</p>
+                </div>
+            </div>
+            <div class="nt-card-default">
+                <div class="nt-card-header">
+                    <span class="nt-card-title">Card Two</span>
+                </div>
+                <div class="nt-card-content">
+                    <p>Example content</p>
+                </div>
+            </div>
+            <div class="nt-card-default">
+                <div class="nt-card-header">
+                    <span class="nt-card-title">Card Three</span>
+                </div>
+                <div class="nt-card-content">
+                    <p>Example content</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/apps/nt-stylesheet/public/components-manifest.json
+++ b/apps/nt-stylesheet/public/components-manifest.json
@@ -1,75 +1,80 @@
 {
-    "version": "1.0.0",
-    "components": [
-        {
-            "name": "Alert",
-            "id": "alert",
-            "type": "Control"
-        },
-        {
-            "name": "Avatar",
-            "id": "avatar",
-            "type": "Control"
-        },
-        {
-            "name": "Badge",
-            "id": "badge",
-            "type": "Control"
-        },
-        {
-            "name": "Breadcrumb",
-            "id": "breadcrumb",
-            "type": "Control"
-        },
-        {
-            "name": "Card",
-            "id": "card",
-            "type": "Control"
-        },
-        {
-            "name": "Checkbox",
-            "id": "checkbox",
-            "type": "Control"
-        },
-        {
-            "name": "Inputs",
-            "id": "inputs",
-            "type": "Control"
-        },
-        {
-            "name": "Label",
-            "id": "label",
-            "type": "Control"
-        },
-        {
-            "name": "Modal",
-            "id": "modal",
-            "type": "Control"
-        },
-        {
-            "name": "Radio Group",
-            "id": "radio-group",
-            "type": "Control"
-        },
-        {
-            "name": "Switch",
-            "id": "switch",
-            "type": "Control"
-        },
-        {
-            "name": "Tooltip",
-            "id": "tooltip",
-            "type": "Control"
-        },
-        {
-            "name": "Table",
-            "id": "table",
-            "type": "Control"
-        },
-        {
-            "name": "Popover",
-            "id": "popover",
-            "type": "Control"
-        }
-    ]
+  "version": "1.0.0",
+  "components": [
+    {
+      "name": "Alert",
+      "id": "alert",
+      "type": "Control"
+    },
+    {
+      "name": "Avatar",
+      "id": "avatar",
+      "type": "Control"
+    },
+    {
+      "name": "Badge",
+      "id": "badge",
+      "type": "Control"
+    },
+    {
+      "name": "Breadcrumb",
+      "id": "breadcrumb",
+      "type": "Control"
+    },
+    {
+      "name": "Card",
+      "id": "card",
+      "type": "Control"
+    },
+    {
+      "name": "Checkbox",
+      "id": "checkbox",
+      "type": "Control"
+    },
+    {
+      "name": "Inputs",
+      "id": "inputs",
+      "type": "Control"
+    },
+    {
+      "name": "Label",
+      "id": "label",
+      "type": "Control"
+    },
+    {
+      "name": "Modal",
+      "id": "modal",
+      "type": "Control"
+    },
+    {
+      "name": "Radio Group",
+      "id": "radio-group",
+      "type": "Control"
+    },
+    {
+      "name": "Switch",
+      "id": "switch",
+      "type": "Control"
+    },
+    {
+      "name": "Tooltip",
+      "id": "tooltip",
+      "type": "Control"
+    },
+    {
+      "name": "Table",
+      "id": "table",
+      "type": "Control"
+    },
+    {
+      "name": "Popover",
+      "id": "popover",
+      "type": "Control"
+    },
+    {
+      "name": "Cards",
+      "id": "cards",
+      "type": "Control"
+    }
+  ]
 }

--- a/apps/nt-stylesheet/src/styles/_components.scss
+++ b/apps/nt-stylesheet/src/styles/_components.scss
@@ -2,6 +2,7 @@
 @use 'components/nt-section';
 @use 'components/nt-form';
 @use 'components/nt-card';
+@use 'components/nt-cards';
 @use 'components/nt-label';
 @use 'components/nt-badge';
 @use 'components/nt-button';

--- a/apps/nt-stylesheet/src/styles/components/_nt-cards.scss
+++ b/apps/nt-stylesheet/src/styles/components/_nt-cards.scss
@@ -1,0 +1,14 @@
+@use '../variables' as vars;
+
+@mixin nt-cards(
+  $gap: vars.$nt-spacing-md,
+  $min-width: 15rem
+) {
+  .nt-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax($min-width, 1fr));
+    gap: $gap;
+  }
+}
+
+@include nt-cards();


### PR DESCRIPTION
## Summary
- add basic cards SCSS
- show example usage
- register cards in manifest
- import cards styles

## Testing
- `pnpm -w lint` *(fails: Need to install packages)*

------
https://chatgpt.com/codex/tasks/task_e_687a0611706483239954e14691c6d950